### PR TITLE
Default Level Group

### DIFF
--- a/dependencies/AreaTally.g.cs
+++ b/dependencies/AreaTally.g.cs
@@ -50,7 +50,7 @@ namespace Elements
         [JsonProperty("Program Type", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string ProgramType { get; set; }
     
-        [JsonProperty("Program Color", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("Program Color", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Color ProgramColor { get; set; }
     
         [JsonProperty("Area Target", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]

--- a/dependencies/ConceptualMass.cs
+++ b/dependencies/ConceptualMass.cs
@@ -87,14 +87,12 @@ namespace Elements
         [JsonIgnore]
         private Guid LevelGroupId { get; set; }
 
-        private static Plane XY = new Plane((0, 0), (0, 0, 1));
-
-        // public List<Guid> LevelIds => 
+        // public List<Guid> LevelIds =>
 
         // public Guid? Building { get; set; }
         public ConceptualMass(MassingOverrideAddition add, double barWidth)
         {
-            Profile = add.Value.Boundary?.Project(XY);
+            Profile = add.Value.Boundary?.Project(Plane.XY);
             Boundary = Profile;
 
 
@@ -125,8 +123,8 @@ namespace Elements
 
         public ConceptualMass(Profile boundary, List<Level> levels, LevelGroup levelGroup)
         {
-            Profile = boundary?.Project(XY);
-            Boundary = boundary?.Project(XY);
+            Profile = boundary?.Project(Plane.XY);
+            Boundary = boundary?.Project(Plane.XY);
             ComputeLCS();
             SetLevelInfo(levels, levelGroup);
             Initialize();
@@ -134,8 +132,8 @@ namespace Elements
 
         public ConceptualMass Update(MassingOverride edit, double barWidth)
         {
-            Profile = edit.Value.Boundary?.Project(XY) ?? Profile;
-            Boundary = edit.Value.Boundary?.Project(XY) ?? Boundary;
+            Profile = edit.Value.Boundary?.Project(Plane.XY) ?? Profile;
+            Boundary = edit.Value.Boundary?.Project(Plane.XY) ?? Boundary;
             PrimaryUseCategory = edit.Value.PrimaryUseCategory ?? PrimaryUseCategory;
 
             TopLevel.Update(edit.Value.TopLevel);
@@ -231,7 +229,7 @@ namespace Elements
                 var b = e.Value.Right.Vertex.Point;
                 if (a.DistanceTo(b) < 0.1)
                 {
-                    return new Line[] { };
+                    return Array.Empty<Line>();
                 }
                 return new[] { new Line(e.Value.Left.Vertex.Point, e.Value.Right.Vertex.Point).TransformedLine(Transform) };
             });
@@ -585,10 +583,7 @@ namespace Elements
             {
                 return currentPolylines;
             }
-            if (currentPolylines == null)
-            {
-                currentPolylines = new List<Polyline>();
-            }
+            currentPolylines ??= new List<Polyline>();
             foreach (var pl in skeleton)
             {
                 if (currentPolylines.Count == 0)

--- a/dependencies/CreateEnvelopes.Dependencies.csproj
+++ b/dependencies/CreateEnvelopes.Dependencies.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="1.1.0" />
-    <PackageReference Include="Hypar.Functions" Version="1.1.1" />
+    <PackageReference Include="Hypar.Elements" Version="1.4.0" />
+    <PackageReference Include="Hypar.Functions" Version="1.4.0" />
   </ItemGroup>
 </Project>

--- a/dependencies/Site.g.cs
+++ b/dependencies/Site.g.cs
@@ -41,7 +41,7 @@ namespace Elements
         }
     
         /// <summary>The perimeter of the site.</summary>
-        [JsonProperty("Perimeter", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("Perimeter", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Polygon Perimeter { get; set; }
     
         /// <summary>The Area of the site.</summary>


### PR DESCRIPTION
A user on discord was running into issues w/ conceptual mass, because they were using an older level function that doesn't produce level groups. (https://hypar.io/workflows/c85afed9-45c9-436a-a255-2a1d69185157 for example)

- handles injecting a default level group, if there isn't one
- makes some .net 6 suggested lint fixes
- turns off dimension drawing along the mass. It didn't look great, and it's slow due to a recent explore change I made. We can bring it back if anybody misses it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/Function-ConceptualMass/1)
<!-- Reviewable:end -->
