### PR TITLE
Fix user reported fails in Conceptual Mass 

### DIFF
--- a/src/CreateEnvelopes.cs
+++ b/src/CreateEnvelopes.cs
@@ -356,6 +356,8 @@ namespace CreateEnvelopes
                 {
                     var extented = rs.Baseline.ExtendTo(profile);
                     var splits = Profile.Split(new[] { profile }, new Polyline(extented.Start, extented.End));
+                    // This area strategy will choose the wrong polygon in some circumstances. 
+                    // TODO: analyze which side of the setback the results are on, and only include results "inside" of the setback line.
                     profile = splits.OrderBy(p => Math.Abs(p.Area())).LastOrDefault() ?? profile;
                 }
                 else
@@ -366,6 +368,8 @@ namespace CreateEnvelopes
                     try
                     {
                         var difference = Profile.Difference(new[] { profile }, new[] { new Profile(rectangleFromSetback) });
+                        // This area strategy will choose the wrong polygon in some circumstances. 
+                        // TODO: analyze which side of the setback the results are on, and only include results "inside" of the setback line.
                         profile = difference.OrderBy(p => Math.Abs(p.Area())).LastOrDefault() ?? profile;
                     }
                     catch

--- a/src/CreateEnvelopes.cs
+++ b/src/CreateEnvelopes.cs
@@ -124,6 +124,12 @@ namespace CreateEnvelopes
             var barWidth = Constants.DEFAULT_BAR_WIDTH;
             if (hasUnitDefinitions)
             {
+                var unitDefs = residentialUnitsModel.AllElementsOfType<UnitDefinition>();
+                if (!unitDefs.Any())
+                {
+                    return barWidth;
+                }
+
                 double? balconyOffset = null;
                 if (hasSiteConstraints)
                 {
@@ -134,7 +140,7 @@ namespace CreateEnvelopes
                         balconyOffset = setbacksWithBalconyRule.Max(s => s.BalconyProtrusionDepth.Value);
                     }
                 }
-                var unitDefs = residentialUnitsModel.AllElementsOfType<UnitDefinition>();
+
                 // choose the largest depth. Include balconies if balconyOffset != null.
                 var greatestDepth = unitDefs.Max(u =>
                 {

--- a/src/CreateEnvelopes.cs
+++ b/src/CreateEnvelopes.cs
@@ -352,17 +352,26 @@ namespace CreateEnvelopes
             // perimeter, we have to revert to a boolean strategy.
             foreach (var rs in remainingSetbacks)
             {
-                var a = rs.Baseline.Offset(rs.Distance, false);
-                var b = rs.Baseline.Offset(rs.Distance, true);
-                var rectangleFromSetback = new Polygon(a.Start, a.End, b.End, b.Start);
-                try
+                if (rs.Distance.ApproximatelyEquals(0))
                 {
-                    var difference = Profile.Difference(new[] { profile }, new[] { new Profile(rectangleFromSetback) });
-                    profile = difference.OrderBy(p => Math.Abs(p.Area())).LastOrDefault() ?? profile;
+                    var extented = rs.Baseline.ExtendTo(profile);
+                    var splits = Profile.Split(new[] { profile }, new Polyline(extented.Start, extented.End));
+                    profile = splits.OrderBy(p => Math.Abs(p.Area())).LastOrDefault() ?? profile;
                 }
-                catch
+                else
                 {
-                    Console.WriteLine("Setback boolean failed.");
+                    var a = rs.Baseline.Offset(rs.Distance, false);
+                    var b = rs.Baseline.Offset(rs.Distance, true);
+                    var rectangleFromSetback = new Polygon(a.Start, a.End, b.End, b.Start);
+                    try
+                    {
+                        var difference = Profile.Difference(new[] { profile }, new[] { new Profile(rectangleFromSetback) });
+                        profile = difference.OrderBy(p => Math.Abs(p.Area())).LastOrDefault() ?? profile;
+                    }
+                    catch
+                    {
+                        Console.WriteLine("Setback boolean failed.");
+                    }
                 }
             }
 

--- a/src/Function.g.cs
+++ b/src/Function.g.cs
@@ -61,18 +61,11 @@ namespace CreateEnvelopes
             Console.WriteLine($"Time to load assemblies: {sw.Elapsed.TotalSeconds})");
 
             if(this.store == null)
-            { 
-                if (args.SignedResourceUrls == null)
-                {
-                    this.store = new S3ModelStore<CreateEnvelopesInputs>(RegionEndpoint.GetBySystemName("us-west-1"));
-                }
-                else
-                {
-                    this.store = new UrlModelStore<CreateEnvelopesInputs>();
-                }
+            {
+                this.store = new S3ModelStore<CreateEnvelopesInputs>(RegionEndpoint.GetBySystemName("us-west-1"));
             }
 
-            var l = new InvocationWrapper<CreateEnvelopesInputs,CreateEnvelopesOutputs> (store, CreateEnvelopes.Execute);
+            var l = new InvocationWrapper<CreateEnvelopesInputs,CreateEnvelopesOutputs>(store, CreateEnvelopes.Execute);
             var output = await l.InvokeAsync(args);
             return output;
         }


### PR DESCRIPTION
https://www.notion.so/hyparaec/Dmytro-1fa29320be7d4b17af29f5ad64e191b6?p=695df962c4874619b2f5e845d7dc48c0&pm=s 
“Residential Units” function above has 0 units and this confuses the function. Units are optional but since function is there it expects at least one unit. Use default bar width in this case.

https://www.notion.so/hyparaec/Dmytro-1fa29320be7d4b17af29f5ad64e191b6?p=65f111958e2e45a984a7a5a286ac9a85&pm=s
Setback has zero distance, and, in this case offset can't be used on it's line. I used Split method instead.
I have some concern about biggest part chosen as main after Split/Difference, but this how it already behave.

The function has some weak spots that can lead to wrong results with specific inputs

